### PR TITLE
Downgrade libraries to .NET 6

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,4 +39,5 @@ jobs:
         if: ${{ inputs.versionSuffix != '' }}
         run: dotnet pack CosmicWorks.Tool/CosmicWorks.Tool.csproj --output out/ --include-symbols /p:VersionPrefix="${{ inputs.versionPrefix }}" /p:VersionSuffix="${{ inputs.versionSuffix }}"
       - name: Push NuGet packages
+        working-directory: ./src/out
         run: dotnet nuget push "**/*.nupkg" --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate

--- a/src/CosmicWorks.Data/CosmicWorks.Data.csproj
+++ b/src/CosmicWorks.Data/CosmicWorks.Data.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>CosmicWorks.Data</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/CosmicWorks.Generator/CosmicWorks.Generator.csproj
+++ b/src/CosmicWorks.Generator/CosmicWorks.Generator.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>CosmicWorks.Generator</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Libraries need to be downgraded to .NET 6 until a .NET Standard 2.x comes along that enforces the latest C# features (record, init-only properties, etc.)