### PR TITLE
Implement setting to hide credentials

### DIFF
--- a/src/CosmicWorks.Tool/Commands/GenerateDataCommand.cs
+++ b/src/CosmicWorks.Tool/Commands/GenerateDataCommand.cs
@@ -31,7 +31,7 @@ public sealed class GenerateDataCommand : AsyncCommand<GenerateDataSettings>
 
         Console.WriteLine(); Console.Write(new Rule("[yellow]Parsing connection string[/]").LeftJustified().RuleStyle("olive")); Console.WriteLine();
 
-        string connectionString = RetrieveConnectionString(settings.ConnectionString, settings.Emulator);
+        string connectionString = RetrieveConnectionString(settings.ConnectionString, settings.Emulator, settings.HideCredentials is false);
 
         Console.WriteLine(); Console.Write(new Rule("[yellow]Populating data[/]").LeftJustified().RuleStyle("olive")); Console.WriteLine();
 
@@ -98,7 +98,7 @@ public sealed class GenerateDataCommand : AsyncCommand<GenerateDataSettings>
         return 0;
     }
 
-    private static string RetrieveConnectionString(string? connectionString, bool emulator)
+    private static string RetrieveConnectionString(string? connectionString, bool emulator, bool showCredentials)
     {
         if (emulator)
         {
@@ -122,7 +122,7 @@ public sealed class GenerateDataCommand : AsyncCommand<GenerateDataSettings>
         }
 
         Console.Write(
-            new Panel($"[teal]{connectionString}[/]")
+            new Panel(showCredentials ? $"[teal]{connectionString}[/]" : $"[teal dim]{new String('*', connectionString.Length)}[/]")
                 .Header("[green]Connection string[/]")
                 .BorderColor(Color.White)
                 .RoundedBorder()

--- a/src/CosmicWorks.Tool/Settings/GenerateDataSettings.cs
+++ b/src/CosmicWorks.Tool/Settings/GenerateDataSettings.cs
@@ -26,6 +26,10 @@ public sealed class GenerateDataSettings : CommandSettings
     [CommandOption("-v|--version <VERSION>")]
     public bool RenderVersion { get; init; } = false;
 
+    [Description("Hides the credentials.")]
+    [CommandOption("--hide-credentials <HIDE_CREDENTIALS>", IsHidden = true)]
+    public bool? HideCredentials { get; init; } = false;
+
     public override ValidationResult Validate()
     {
         return (NumberOfProducts, NumberOfEmployees) switch


### PR DESCRIPTION
Add new unpublished ``--hide-credentials`` setting to mask the connection string.

This is ideal for scenarios when you wish to use the tool as part of an ARM/Bicep deployment script.