### PR TITLE
Implement format disabling

### DIFF
--- a/src/CosmicWorks.Tool/Settings/GenerateDataSettings.cs
+++ b/src/CosmicWorks.Tool/Settings/GenerateDataSettings.cs
@@ -30,6 +30,10 @@ public sealed class GenerateDataSettings : CommandSettings
     [CommandOption("--hide-credentials <HIDE_CREDENTIALS>", IsHidden = true)]
     public bool? HideCredentials { get; init; } = false;
 
+    [Description("Disables ANSI and color formatting for console output.")]
+    [CommandOption("--disable-formatting <DISABLE_FORMATTING>", IsHidden = true)]
+    public bool? DisableFormatting { get; init; } = false;
+
     public override ValidationResult Validate()
     {
         return (NumberOfProducts, NumberOfEmployees) switch


### PR DESCRIPTION
Add `--disable-formatting` as an unpublished setting to disable ANSI and color formatting on the console. This is useful for reading raw text logs where this tool was used in an unattended manner.